### PR TITLE
Fix for https://issues.infn.it/jira/browse/STOR-750

### DIFF
--- a/src/frontend/file_request.hpp
+++ b/src/frontend/file_request.hpp
@@ -27,6 +27,7 @@ extern "C" {
 #include <vector>
 #include <string>
 #include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #include "storm_exception.hpp"
 #include "srmv2H.h"
@@ -152,11 +153,10 @@ public:
     std::string sqlFormat(bool b){
     	return b ? "1" : "0";
     }
+
     std::string sqlFormat(std::string const& s){
-    	std::string formatted_s("\'");
-    	formatted_s += s;
-    	formatted_s += '\'';
-    	return formatted_s;
+    	std::string formatted_s = boost::replace_all_copy(s, "'", "''");
+    	return '\'' + formatted_s + '\'';
     }
 
 	void setFileStorageType(ns1__TFileStorageType type) {


### PR DESCRIPTION
Single quote in certificate subject causes failures in StoRM async requests.
The problem is that characters in certificate subjects are not properly escaped by the StoRM Frontend.
The solution proposed is modify the function used to format all the query parameters. Each occurrence of a single quote is escaped by replacing it with two single quotes.