### PR TITLE
Issue 1170

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 AC_PREREQ([2.59])
-AC_INIT([storm frontend server], [1.8.12], andrea.ceccanti@cnaf.infn.it)
+AC_INIT([storm frontend server], [1.8.13], andrea.ceccanti@cnaf.infn.it)
 
 AC_CONFIG_AUX_DIR([./aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/etc/init.d/storm-frontend-server.in
+++ b/etc/init.d/storm-frontend-server.in
@@ -158,7 +158,7 @@ case "$1" in
         RETVAL=0
     else
         echo -n "Stopping $prog.."
-        kill -9 `cat $PIDFILE` >& /dev/null
+        kill -2 `cat $PIDFILE` >& /dev/null
         if [ $? -eq 0 ]; then
             check_if_running
             while [ $? -eq $TRUE ]; do

--- a/etc/init.d/storm-frontend-server.in
+++ b/etc/init.d/storm-frontend-server.in
@@ -139,7 +139,7 @@ case "$1" in
     FE_ERR="$RUNDIR/storm-frontend-server.err"
 
     # Launch the frontend
-    su -m -s "/bin/bash" -c "$FRONTEND_DAEMON -c $CONFIGURATION_FILE 1>$FE_OUT 2>$FE_ERR" $STORM_FE_USER
+    su -m -s "/bin/bash" -c "ASAN_OPTIONS=log_path=/tmp/storm-fe-asan.log $FRONTEND_DAEMON -c $CONFIGURATION_FILE 1>$FE_OUT 2>$FE_ERR" $STORM_FE_USER
 
     if [ $? -eq 0 ]; then
       pid=$(ps -eo pid,ppid,comm | grep " [0-9] ${prog_short}$" | awk '{print $1}')

--- a/etc/init.d/storm-frontend-server.in
+++ b/etc/init.d/storm-frontend-server.in
@@ -139,7 +139,7 @@ case "$1" in
     FE_ERR="$RUNDIR/storm-frontend-server.err"
 
     # Launch the frontend
-    su -m -s "/bin/bash" -c "ASAN_OPTIONS=log_path=/tmp/storm-fe-asan.log $FRONTEND_DAEMON -c $CONFIGURATION_FILE 1>$FE_OUT 2>$FE_ERR" $STORM_FE_USER
+    su -m -s "/bin/bash" -c "$FRONTEND_DAEMON -c $CONFIGURATION_FILE 1>$FE_OUT 2>$FE_ERR" $STORM_FE_USER
 
     if [ $? -eq 0 ]; then
       pid=$(ps -eo pid,ppid,comm | grep " [0-9] ${prog_short}$" | awk '{print $1}')

--- a/src/frontend/Monitor.hpp
+++ b/src/frontend/Monitor.hpp
@@ -99,7 +99,7 @@ class Monitor {
 			this->aggregated_status.reset();
 		};
 
-		~Monitor() {};
+		virtual ~Monitor() {};
 
 		const std::string getName()
 		{

--- a/src/frontend/srmlogit.cpp
+++ b/src/frontend/srmlogit.cpp
@@ -52,12 +52,12 @@ static bool m_auditEnabled;
  *
  **/
 int srmlogit_init(const char* logfile, const char* auditfile, int auditEnabled) {
+	int result = 0;
 
 	m_auditEnabled = auditEnabled;
     if (NULL == logfile) {
 
         log_fd = stderr;
-        return 0;
 
     } else {
 
@@ -65,7 +65,7 @@ int srmlogit_init(const char* logfile, const char* auditfile, int auditEnabled) 
 
         if (log_fd == NULL) {
             fprintf(stderr, "Cannot open log file %s\n", logfile);
-            return 1;
+            result = 1;
         }
     }
 
@@ -73,7 +73,6 @@ int srmlogit_init(const char* logfile, const char* auditfile, int auditEnabled) 
         if (NULL == auditfile) {
 
             audit_fd = stderr;
-            return 0;
 
         } else {
 
@@ -84,14 +83,14 @@ int srmlogit_init(const char* logfile, const char* auditfile, int auditEnabled) 
                 if (log_fd != NULL) {
                     fclose(log_fd);
                 }
-                return 1;
+                result = 1;
             }
         }
     } else {
         audit_fd = NULL;
     }
 
-    return 0;
+    return result;
 }
 
 int srmlogit_set_debuglevel(int level) {

--- a/src/frontend/storm-frontend.cpp
+++ b/src/frontend/storm-frontend.cpp
@@ -522,13 +522,6 @@ void init_globus_threading() {
 
 int main(int argc, char** argv) {
 
-	try {
-		init_globus_threading();
-	} catch (storm::storm_error& e) {
-		std::cerr << e.what() << std::endl;
-		exit(1);
-	}
-
 	int ret = loadConfiguration(argc, argv);
 	if (ret != 0) {
 		if (ret > 0) {
@@ -560,15 +553,9 @@ int main(int argc, char** argv) {
 			return 0;
 		}
 	}
-	try {
-		storm::ThreadPool::buildInstance(configuration->getNumThreads(), configuration->getThreadpoolMaxPending());
-	} catch (boost::thread_resource_error& e) {
-		cout
-				<< "Cannot create all the requested threads, not enough resources.\n";
-		return SYERR;
-	}
 
 	curl_global_init(CURL_GLOBAL_ALL);
+
 	xmlrpc_env env;
 	xmlrpc_env_init(&env);
     xmlrpc_client_setup_global_const(&env);
@@ -578,12 +565,27 @@ int main(int argc, char** argv) {
 		return SYERR;
 	}
 	xmlrpc_env_clean(&env);
+
+
+	try {
+		init_globus_threading();
+	} catch (storm::storm_error& e) {
+		std::cerr << e.what() << std::endl;
+		exit(1);
+	}
+
 	soap* soap_data = initSoap();
 	if (soap_data == NULL) {
 		return SYERR;
 	}
 
-
+	try {
+		storm::ThreadPool::buildInstance(configuration->getNumThreads(), configuration->getThreadpoolMaxPending());
+	} catch (boost::thread_resource_error& e) {
+		cout
+				<< "Cannot create all the requested threads, not enough resources.\n";
+		return SYERR;
+	}
 
 	// the size of mysql_connection pool and thread pool MUST be the same
 	mysql_connection_pool = new DBConnectionPool(


### PR DESCRIPTION
Restructure the initial part of `main` to do the initialization of third-party libs like curl, xmlrpc and soap before entering multi-threaded mode.

Incorporate also minor changes that address a small memory leak, a segmentation fault and signal management, first applied to branch issue-1169, from which this branch has been forked.